### PR TITLE
Pin GH actions to SHA to avoid mutable refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: build
-
-on: [ pull_request, push ]
-
+on: [pull_request, push]
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
@@ -10,7 +8,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,12 @@
 name: draft release
-
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [ opened, reopened, synchronize ]
-
+    types: [opened, reopened, synchronize]
 jobs:
   update_release_draft:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
GitHub actions are mutable if not pinned, which allow modifications without revision changes. Let's pin external versions to ensure the version specified matches the version GH action pulls.